### PR TITLE
Fix the synId overflow test in kernel

### DIFF
--- a/carlsim/kernel/inc/error_code.h
+++ b/carlsim/kernel/inc/error_code.h
@@ -93,4 +93,6 @@
 #define UNKNOWN_LOGGER_ERROR				0x8001
 #define NO_LOGGER_DIR_ERROR					0x8002
 
+#define ID_OVERFLOW_ERROR					0x8003
+
 #endif

--- a/carlsim/test/core.cpp
+++ b/carlsim/test/core.cpp
@@ -636,3 +636,18 @@ TEST(Core, saveLoadSimulation) {
 		}
 	}
 }
+
+TEST(Core, synapseIdOverflow) {
+	::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+	CARLsim sim("Core.synapseIdOverflow", HYBRID_MODE, SILENT, 0, 42);
+
+	int gExc = sim.createGroup("exc", 80000, EXCITATORY_NEURON, 0, CPU_CORES);
+	sim.setNeuronParameters(gExc, 0.02f, 0.2f, -65.0f, 8.0f); // RS
+	int gInput = sim.createSpikeGeneratorGroup("input", 1, EXCITATORY_NEURON, 0, CPU_CORES);
+
+	// make connections more than 65535
+	sim.connect(gInput, gExc, "full", RangeWeight(1.0), 1.0f, RangeDelay(1), RadiusRF(-1), SYN_FIXED);
+	
+	EXPECT_DEATH({ sim.setupNetwork(); }, ""); //sim.setupNetwork();
+}


### PR DESCRIPTION
The maximum number of synapses per neuron supported by current kernel is 2^16, which is 65536. This fix changes synId (synapse id) overflow test in the kernel. Also, this fix added a test case to test synId overflow.