### PR TITLE
Fix GPU_MODE speed issue

### DIFF
--- a/carlsim/carlsim.mk
+++ b/carlsim/carlsim.mk
@@ -142,7 +142,7 @@ prep_release:
 
 prep_debug:
 	$(eval CXXFL += -g -Wall -O0)
- 	$(eval NVCCFL += -g -G --compiler-options "-Wall -O0")
+	$(eval NVCCFL += -g -G --compiler-options "-Wall -O0")
 
 prep_coverage:
 	$(eval CXXFL += -fprofile-arcs -ftest-coverage)

--- a/carlsim/configure.mk
+++ b/carlsim/configure.mk
@@ -111,9 +111,25 @@ NVCCFL             += -D__CUDA$(NVCC_MAJOR_NUM)__
 
 # CUDA code generation flags
 GENCODE_SM20       := -gencode arch=compute_20,code=sm_20
-GENCODE_SM30       := -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=\"sm_35,compute_35\"
-NVCCFL             += $(GENCODE_SM20) $(GENCODE_SM30)
+GENCODE_SM30       := -gencode arch=compute_30,code=sm_30
+GENCODE_SM35       := -gencode arch=compute_35,code=sm_35
+GENCODE_SM50       := -gencode arch=compute_50,code=sm_50
+GENCODE_SM52       := -gencode arch=compute_52,code=sm_52
+GENCODE_SM60       := -gencode arch=compute_60,code=sm_60
+GENCODE_SM61       := -gencode arch=compute_61,code=sm_61
+GENCODE_SM70       := -gencode arch=compute_70,code=sm_70
+# Common to all supported CUDA versions:
+NVCCFL             += $(GENCODE_SM30) $(GENCODE_SM35) $(GENCODE_SM50) $(GENCODE_SM52)
 NVCCFL             += -Wno-deprecated-gpu-targets
+# Additional CC for CUDA >= 8:
+$(if $(shell [ $(NVCC_MAJOR_NUM) -ge 8 ] && echo "OK"), \
+	$(eval NVCCFL += $(GENCODE_SM60) $(GENCODE_SM61)) \
+)
+# Additional CC for CUDA >= 9 (CC2.0 is obsolete)
+$(if $(shell [ $(NVCC_MAJOR_NUM) -ge 9 ] && echo "OK"), \
+	$(eval NVCCFL += $(GENCODE_SM70)), \
+	$(eval NVCCFL += $(GENCODE_SM20)) \
+)
 
 # OS-specific build flags
 ifneq ($(DARWIN),)


### PR DESCRIPTION
This PR should fix the `GPU_MODE` speed issue.

The problem was that the `-Wall -O0` config was executed even during release build, slowing everything down... It came down to a space character (instead of a tab) that caused a silent parsing error in carlsim.mk.

I have also added compute capability flags for CC 5.0, 5.2, 6.0, 6.1, and 7.0. Compiling with CUDA 8 includes CC 2.0 - CC 6.1, CUDA 9 includes CC 3.0 - CC 7.0.