### PR TITLE
Update regex to support 1 or more numbers in nvcc compiler version

### DIFF
--- a/carlsim/configure.mk
+++ b/carlsim/configure.mk
@@ -110,7 +110,7 @@ endif
 
 
 # find NVCC version
-NVCC_MAJOR_NUM     := $(shell nvcc -V 2>/dev/null | grep -o 'release [0-9]\.' | grep -o '[0-9]')
+NVCC_MAJOR_NUM     := $(shell nvcc -V 2>/dev/null | grep -o 'release [0-9]\+\.' | grep -o '[0-9]\+')
 NVCCFL             += -D__CUDA$(NVCC_MAJOR_NUM)__
 
 # CUDA code generation flags


### PR DESCRIPTION
In order to support CUDA 10, regex needs to be updated otherwise no numbers are selected.