### PR TITLE
Update Chapter 4 of User Guide 

### DIFF
--- a/doc/source/user_guide/4_connections/chapter4.dox
+++ b/doc/source/user_guide/4_connections/chapter4.dox
@@ -425,6 +425,7 @@ The following code snippet shows a simple example that creates a one-to-one conn
 
 // custom ConnectionGenerator
 class MyConnection : public ConnectionGenerator {
+public:
 	MyConnection() {}
 	~MyConnection() {}
 
@@ -451,7 +452,7 @@ int main() {
 	// ... etc. ...
 
 	// create an instance of MyConnection class and pass it to CARLsim::connect
-	MyConnection myConn;
+	MyConnection* myConn = new MyConnection;
 	sim.connect(g0, g1, myConn, SYN_PLASTIC);
 
 	sim.setupNetwork();


### PR DESCRIPTION
The current example in Section 4.3 of the User Guide for user-defined connections does not appear to be a working example.  I've updated two lines of the example to have code that can be copied directly.